### PR TITLE
Add task for Prettier which adds the Thorough configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -315,9 +315,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "has-ansi": {
       "version": "2.0.0",
@@ -463,9 +463,9 @@
       }
     },
     "mrm-core": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-3.3.0.tgz",
-      "integrity": "sha512-3A7RAwRmAfVpUxQxxfvX5exQH9+pVGRUPM5ZRwQjCC5BTS8XkjjeOt1Svtc89idIpQGxRixbQ95jBRw8tjO2rw==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/mrm-core/-/mrm-core-3.3.4.tgz",
+      "integrity": "sha512-vTywqjBrQIDlRuoww+xspvm/be272c2M54VY2GWY4NCZtSSG3uY6zyEuQekKANM5HEKc8WVn+jQGHmdETQCtww==",
       "requires": {
         "babel-code-frame": "^6.26.0",
         "comment-json": "^1.1.3",
@@ -473,10 +473,10 @@
         "editorconfig": "^0.15.0",
         "find-up": "^3.0.0",
         "fs-extra": "^7.0.0",
-        "js-yaml": "^3.12.0",
+        "js-yaml": "^3.13.0",
         "kleur": "^2.0.2",
         "listify": "^1.0.0",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.11",
         "minimist": "^1.2.0",
         "prop-ini": "^0.0.2",
         "readme-badger": "^0.3.0",
@@ -484,7 +484,7 @@
         "smpltmpl": "^1.0.2",
         "split-lines": "^2.0.0",
         "strip-bom": "^3.0.0",
-        "webpack-merge": "^4.1.4"
+        "webpack-merge": "^4.2.1"
       }
     },
     "once": {
@@ -497,9 +497,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
       "requires": {
         "p-try": "^2.0.0"
       }
@@ -535,9 +535,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "prop-ini": {
@@ -766,9 +766,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
-      "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.2.tgz",
+      "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
     "universalify": {
@@ -777,11 +777,11 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "webpack-merge": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.1.tgz",
-      "integrity": "sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+      "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
       "requires": {
-        "lodash": "^4.17.5"
+        "lodash": "^4.17.15"
       }
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "author": "Zachary Jones <zachary@thorough.company>",
   "license": "MIT",
   "dependencies": {
-    "mrm-core": "^3.3.0"
+    "mrm-core": "^3.3.4"
   },
   "devDependencies": {
     "@thorough/dev-configs": "^0.3.1",
-    "prettier": "^1.18.2",
-    "typescript": "^3.5.2"
+    "prettier": "^1.19.1",
+    "typescript": "^3.8.2"
   }
 }

--- a/prettier/index.js
+++ b/prettier/index.js
@@ -1,0 +1,47 @@
+const path = require('path');
+const { json, packageJson, install } = require('mrm-core');
+const { getExtsFromCommand } = require('mrm-core');
+const prettierConfig = require('@thorough/dev-configs/prettier.config');
+
+// This file is adapted from the default `prettier` task available from MRM itself.
+
+const defaultPattern = '**/*.{jsx,ts,tsx,css,md}';
+
+function task(config) {
+  const packages = ['prettier'];
+  const pkg = packageJson();
+
+  const { prettierPattern } = config
+    .defaults({ prettierPattern: defaultPattern })
+    .values();
+
+  // .prettierrc
+  json('.prettierrc')
+    .merge(prettierConfig)
+    .save();
+
+  // Keep custom pattern
+  let pattern = prettierPattern;
+  const formatScript = pkg.getScript('format');
+  if (formatScript) {
+    const exts = getExtsFromCommand(formatScript);
+    if (exts) {
+      pattern = `**/*.{${exts}}`;
+    }
+  }
+
+  pkg
+    // Add format script
+    // Double quotes are essential to support Windows:
+    // https://github.com/prettier/prettier/issues/4086#issuecomment-370228517
+    .setScript('format', `prettier --loglevel warn --write "${pattern}"`)
+    // Add pretest script
+    .appendScript('posttest', 'npm run format')
+    .save();
+
+  // Dependencies
+  install(packages);
+}
+
+task.description = 'Adds Prettier';
+module.exports = task;


### PR DESCRIPTION
This changeset adds a `prettier` task which adds Prettier to the project and prepopulates its configuration with the latest Thorough Prettier configuration from [@thorough/dev-configs](https://github.com/thorough-dev/dev-configs).